### PR TITLE
Add dry-run mode for relay control

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -18,4 +18,7 @@
 #define COIL_ON_FOR_OPEN 0 // 1 if relay coil should be energized when zone is open
 #define ZONE_PULSE_MS 3000
 
+// Set to 0 to disable physical relay activation for testing
+#define ACTUATE_RELAYS 1
+
 #endif // CONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,9 +55,13 @@ void applyZones() {
     DEBUG_PRINT("Applying zones: ");
     for (uint8_t i = 0; i < NUM_ZONES; ++i) {
         DEBUG_PRINT(zoneState[i] ? "1" : "0");
+#if ACTUATE_RELAYS
         setRelay(i, coilStateForZone(zoneState[i]));
+#endif
     }
     DEBUG_PRINTLN("");
+
+#if ACTUATE_RELAYS
     writeShiftRegister();
 
     // master relay on
@@ -74,6 +78,9 @@ void applyZones() {
         setRelay(i, false);
     }
     writeShiftRegister();
+#else
+    DEBUG_PRINTLN(" (dry run - relays not actuated)");
+#endif
 
     publishAllStates();
 }


### PR DESCRIPTION
## Summary
- add `ACTUATE_RELAYS` flag in `config.h`
- respect flag in `applyZones()` so relays can be disabled during testing

## Testing
- `pip install platformio`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6846966abbd0832b9615d15442af7f0b