### PR TITLE
Add zone name publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project controls multiple zone relays using an ESP32 and MQTT. It is design
 - State stored in NVS so zones resume their last state after power loss.
 - Dry‑run mode by setting `ACTUATE_RELAYS` to `0` in `include/config.h`.
 - Self‑calibrates its current sensor at boot, so start the controller with no load connected.
+- Zone display names defined in `include/config.h` and published over MQTT.
 
 ## Hardware
 
@@ -38,6 +39,12 @@ Current state is published to:
 
 ```
 <baseTopic>/zone<n>/state  (payload `ON` or `OFF`)
+```
+
+Each zone's configured name is also published when MQTT connects:
+
+```
+<baseTopic>/zone<n>/name   (payload is the display name)
 ```
 
 Home Assistant discovery is sent under `homeassistant/switch/<device>/zone<n>/config` when MQTT connects.

--- a/include/config.h
+++ b/include/config.h
@@ -11,4 +11,10 @@
 
 #define MASTER_DELAY 100
 
+static const char* const ZONE_NAMES[MAX_ZONES] = {
+    "Zone 1", "Zone 2", "Zone 3", "Zone 4", "Zone 5",
+    "Zone 6", "Zone 7", "Zone 8", "Zone 9", "Zone 10",
+    "Zone 11", "Zone 12", "Zone 13", "Zone 14", "Zone 15"
+};
+
 #endif // CONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,9 +175,21 @@ void publishZoneState(uint8_t zone) {
 
 }
 
+void publishZoneName(uint8_t zone) {
+    char topic[64];
+    snprintf(topic, sizeof(topic), "%s/zone%u/name", baseTopic, zone + 1);
+    mqttClient.publish(topic, ZONE_NAMES[zone], true);
+}
+
 void publishAllStates() {
     for (uint8_t i = 0; i < numZones; ++i) {
         publishZoneState(i);
+    }
+}
+
+void publishAllZoneNames() {
+    for (uint8_t i = 0; i < numZones; ++i) {
+        publishZoneName(i);
     }
 }
 
@@ -262,8 +274,8 @@ void sendDiscovery() {
 
         char payload[256];
         snprintf(payload, sizeof(payload),
-                "{\"name\":\"Zone %u\",\"command_topic\":\"%s/zone%u/set\",\"state_topic\":\"%s/zone%u/state\",\"uniq_id\":\"%s_zone%u\",\"payload_on\":\"ON\",\"payload_off\":\"OFF\"}",
-                i + 1, baseTopic, i + 1, baseTopic, i + 1,
+                "{\"name\":\"%s\",\"command_topic\":\"%s/zone%u/set\",\"state_topic\":\"%s/zone%u/state\",\"uniq_id\":\"%s_zone%u\",\"payload_on\":\"ON\",\"payload_off\":\"OFF\"}",
+                ZONE_NAMES[i], baseTopic, i + 1, baseTopic, i + 1,
                 iotWebConf.getThingName(), i + 1);
         DEBUG_PRINT("sending payload: ");
         DEBUG_PRINTLN(payload);
@@ -327,6 +339,7 @@ bool connectMqtt() {
         mqttClient.subscribe(sub.c_str());
         sendDiscovery();
         publishAllStates();
+        publishAllZoneNames();
         publishCurrent();
         return true;
     } else {


### PR DESCRIPTION
## Summary
- define default zone display names in `config.h`
- publish zone names on `<baseTopic>/zone<n>/name`
- use zone names in Home Assistant discovery
- document zone name topics in README

## Testing
- `pip install platformio`
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_684e5b5cce08832b8d1a3c15cfb80b1f