### PR TITLE
Add empty HA prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ following pins by default:
 
 ## MQTT Topics
 
-The default base topic is `8zone-controller`. Topics are automatically published under the `homeassistant/` prefix. Each zone `n` (1‑15) listens for commands on:
+The default base topic is `8zone-controller`. Topics are automatically published under the `homeassistant/` prefix. This prefix can be removed by setting `HA_PREFIX` to an empty string in `src/main.cpp`. Each zone `n` (1‑15) listens for commands on:
 
 ```
 homeassistant/<baseTopic>/zone<n>/set    (payload `ON` or `OFF`)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <WebServer.h>
 #include <IotWebConf.h>
 #include <IotWebConfUsing.h>
+#include <string.h>
 
 #include "config.h"
 #include "debug.h"
@@ -35,6 +36,7 @@ PubSubClient mqttClient(wifiClient);
 
 #define DEVICE_NAME "8zone-controller"
 #define HA_PREFIX "homeassistant"
+//#define HA_PREFIX ""  // Uncomment to disable the prefix
 
 const char THING_NAME[] = DEVICE_NAME;
 const char INITIAL_AP_PASSWORD[] = "zonezone";
@@ -182,7 +184,12 @@ void updateConfigVariables() {
     zonePulseMs = (unsigned long)atoi(pulseSecondsStr) * 1000;
     coilOnForOpenFlag = !invertRelaysParam.isChecked();
     useShiftRegisters = strncmp(relayModeValue, "gpio", 4) != 0;
-    snprintf(haBaseTopic, sizeof(haBaseTopic), "%s/%s", HA_PREFIX, baseTopic);
+    if (strlen(HA_PREFIX) == 0) {
+        strncpy(haBaseTopic, baseTopic, sizeof(haBaseTopic));
+        haBaseTopic[sizeof(haBaseTopic) - 1] = '\0';
+    } else {
+        snprintf(haBaseTopic, sizeof(haBaseTopic), "%s/%s", HA_PREFIX, baseTopic);
+    }
     parseDefaultZones();
     DEBUG_PRINTLN(String("CONFIG INVERTED: ") + (coilOnForOpenFlag ? "true" : "false"));
     DEBUG_PRINTLN(String("CONFIG RELAY MODE: ") + (useShiftRegisters ? "shift" : "gpio"));


### PR DESCRIPTION
## Summary
- allow HA_PREFIX to be blank
- document no-prefix option in README

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_685e98e7a8ac832ba10817c1c24f184b